### PR TITLE
Makefile failtests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+*.lps
+*.lts
+*.swap

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,9 @@
-PROJECT_NAME = Railway_crossing
+MODEL_NAME = Railway_crossing
 PFL = Verified_model
 TFL = Verified_model/Verification_files
 
-FILES = $(PFL)/$(PROJECT_NAME).lts \
-	$(PFL)/$(PROJECT_NAME).lps
+FILES = $(PFL)/$(MODEL_NAME).lts \
+	$(PFL)/$(MODEL_NAME).lps
 
 TESTS = $(TFL)/0-No_deadlock_is_present_in_the_system.bool \
 	$(TFL)/10-From_every_reachable_state_there_is_a_sequence_of_actions_to_a_state_in_which_the_barriers_are_raised.bool \
@@ -30,12 +30,8 @@ tests: $(TESTS)
 %.lts: %.lps
 	lps2lts $< $@
 
-#Railway_Crossing.lts: Railway_Crossing.lps
-#	lps2lts -rjittyc -v $< $@
-
-%.pbes: %.mcf $(PFL)/Railway_crossing.lps
-	lps2pbes -f$< $(PFL)/Railway_crossing.lps $@
-
+%.pbes: %.mcf $(PFL)/$(MODEL_NAME).lps
+	lps2pbes -f$< $(PFL)/$(MODEL_NAME).lps $@
 
 %.bool: %.pbes
 	@pbes2bool $<
@@ -43,4 +39,3 @@ tests: $(TESTS)
 clean:
 	rm -f $(PFL)/*.lps
 	rm -f $(PFL)/*.lts
-

--- a/Makefile
+++ b/Makefile
@@ -6,20 +6,20 @@ FILES = $(PFL)/$(MODEL_NAME).lts \
 	$(PFL)/$(MODEL_NAME).lps
 
 TESTS = $(TFL)/0-No_deadlock_is_present_in_the_system.bool \
-	$(TFL)/10-From_every_reachable_state_there_is_a_sequence_of_actions_to_a_state_in_which_the_barriers_are_raised.bool \
+	$(TFL)/1-The_barriers_are_set_when_a_train_passes_over_the_crossing.bool \
 	$(TFL)/1a-Trains_can_cross_if_the_barriers_are_set.bool \
 	$(TFL)/1b-Trains_cannot_cross_if_the_barriers_are_raised_init.bool \
 	$(TFL)/1c-Trains_cannot_cross_if_the_barriers_are_raised_no_init.bool \
-	$(TFL)/1-The_barriers_are_set_when_a_train_passes_over_the_crossing.bool \
-	$(TFL)/5a-The_bell_cannot_turn_on_if_the_lights_have_not_yet_been_turned_on_init.bool \
-	$(TFL)/5b-The_bell_cannot_turn_on_if_the_lights_have_not_yet_been_turned_on_no_init.bool \
 	$(TFL)/5-The_bell_cannot_turn_on_if_the_lights_have_not_yet_been_turned_on.bool \
+	$(TFL)/5b-The_bell_cannot_turn_on_if_the_lights_have_not_yet_been_turned_on_no_init.bool \
+	$(TFL)/5a-The_bell_cannot_turn_on_if_the_lights_have_not_yet_been_turned_on_init.bool \
+	$(TFL)/6-The_barriers_cannot_be_set_if_the_bell_has_not_yet_been_turned_on.bool \
 	$(TFL)/6a-The_barriers_cannot_be_set_if_the_bell_has_not_yet_been_turned_on_init.bool \
 	$(TFL)/6b-The_barriers_cannot_be_set_if_the_bell_has_not_yet_been_turned_on_no_init.bool \
-	$(TFL)/6-The_barriers_cannot_be_set_if_the_bell_has_not_yet_been_turned_on.bool \
 	$(TFL)/7-The_bell_cannot_be_turned_off_if_the_barriers_are_set.bool \
 	$(TFL)/8-The_lights_cannot_be_turned_off_if_the_bell_is_on.bool \
-	$(TFL)/9-From_every_reachable_state_there_is_a_sequence_of_actions_to_a_state_in_which_the_barriers_are_set.bool
+	$(TFL)/9-From_every_reachable_state_there_is_a_sequence_of_actions_to_a_state_in_which_the_barriers_are_set.bool \
+	$(TFL)/10-From_every_reachable_state_there_is_a_sequence_of_actions_to_a_state_in_which_the_barriers_are_raised.bool \
 
 all: $(FILES)
 tests: $(TESTS)
@@ -34,6 +34,7 @@ tests: $(TESTS)
 	lps2pbes -f$< $(PFL)/$(MODEL_NAME).lps $@
 
 %.bool: %.pbes
+	@echo "Running test: $<"
 	@pbes2bool $<
 
 clean:

--- a/simple-testchecker.sh
+++ b/simple-testchecker.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+make tests | grep '^false$' &> /dev/null
+if [ $? == 0 ]; then
+    echo "A test failed!"
+else
+    echo "All tests passed"
+fi

--- a/testchecker.sh
+++ b/testchecker.sh
@@ -1,8 +1,36 @@
 #!/bin/sh
+# Tests the checks against non correct models to determine the validity of
+# the tests themselves.
 
-make tests | grep '^false$' &> /dev/null
-if [ $? == 0 ]; then
-    echo "A test failed!"
-else
-    echo "All tests passed"
-fi
+# Comment out SHOW_TEST to only show true or false (so leave out the test names)
+SHOW_TEST="TRUE"
+
+function showTest {
+    tmp="$1"
+    if [ "$SHOW_TEST" = "TRUE" ]; then
+        outp="${tmp//Running test: Verified_model\/Verification_files\//Test: }"
+        echo "${outp//".pbes"/}"
+    else
+        echo "$tmp" | egrep '^(false|true)$'
+    fi
+}
+
+DEAD_MODEL="Railway_crossing_dead"
+UNSAFE_MODEL="Railway_crossing_unsafe"
+EGREP_STR="(Running test:)|(^(false|true)$)"
+
+echo "Running the regular tests"
+output=$(make tests | egrep "$EGREP_STR")
+showTest "$output"
+echo
+
+echo "Running the dead tests"
+output=$(make MODEL_NAME=$DEAD_MODEL tests | egrep "$EGREP_STR")
+showTest "$output"
+echo
+
+echo "Running the unsafe tests"
+output=$(make MODEL_NAME=$UNSAFE_MODEL tests | egrep "$EGREP_STR")
+showTest "$output"
+echo
+

--- a/testchecker.sh
+++ b/testchecker.sh
@@ -3,7 +3,7 @@
 # the tests themselves.
 
 # Comment out SHOW_TEST to only show true or false (so leave out the test names)
-SHOW_TEST="TRUE"
+#SHOW_TEST="TRUE"
 
 function showTest {
     tmp="$1"
@@ -17,6 +17,7 @@ function showTest {
 
 DEAD_MODEL="Railway_crossing_dead"
 UNSAFE_MODEL="Railway_crossing_unsafe"
+NOHIDE_MODEL="Railway_crossing_nohide"
 EGREP_STR="(Running test:)|(^(false|true)$)"
 
 echo "Running the regular tests"
@@ -34,3 +35,7 @@ output=$(make MODEL_NAME=$UNSAFE_MODEL tests | egrep "$EGREP_STR")
 showTest "$output"
 echo
 
+echo "Running the no-hide tests"
+output=$(make MODEL_NAME=$NOHIDE_MODEL tests | egrep "$EGREP_STR")
+showTest "$output"
+echo


### PR DESCRIPTION
- Changes the `testchecker.sh` script to check:
  - The regular tests against Railway_crossing
  - The test verification checks against Railway_crossing_dead
  - The test verification checks against Railway_crossing_unsafe
  - The test verification checks against Railway_crossing_nohide
- Added a `simple-testchecker.sh` script that only checks the tests against Railway_crossing and only reports true if all are true and false if at least one is false.
- Added a gitignore
